### PR TITLE
feat: 게시글 수정 구현

### DIFF
--- a/static/assets/js/edit.js
+++ b/static/assets/js/edit.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', detail);
+document.getElementById('edit-btn').addEventListener('click', edit)
 
 // url에서 board_id 가져오기
 const param = window.location.search;
@@ -13,15 +14,47 @@ function detail() {
         data: {},
         success: function (response) {
 
-            // 게시글 부분
             let rows = response['worry'];
             let nickname = rows['nickname'];
             let title = rows['title'];
             let desc = rows['desc'];
 
+            // 받아온 데이터 input 태그로 출력
             document.getElementById('nickname').value = nickname;
             document.getElementById('title').value = title;
             document.getElementById('desc').value = desc;
         }
     });
+}
+
+// 비밀번호가 일치하는지 확인하고 업데이트
+function edit() {
+    let nickname = document.getElementById('nickname').value;
+    let title = document.getElementById('title').value;
+    let password = document.getElementById('password').value;
+    let desc = document.getElementById('desc').value;
+
+    $.ajax({
+        type: 'POST',
+        url: '/worry/edit',
+        data: {
+            board_id_give: board_id,
+            nickname_give: nickname,
+            title_give: title,
+            password_give: password,
+            desc_give: desc,
+        },
+        success: function (response) {
+
+            // 비밀번호가 일치하여 update 되었으면, 해당 detail 페이지로 이동
+            if (response['msg']) {
+                window.location.replace('/detail?id=' + board_id);
+            }
+            // 비밀번호가 일치하지 않으면, alert
+            else {
+                alert('비밀번호가 일치하지 않습니다. 다시 확인해 주세요.')
+                document.getElementById('password').value ='';
+            }
+        }
+    })
 }

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -52,25 +52,45 @@
         <div class="container aos-init aos-animate">
             <div class="col-lg-7">
                 <div class="comments card p-5">
-                    <form class="my_board">
+                    <div class="my_board">
                         <fieldset>
-                            <legend>대나무숲 게시판 수정</legend>
-                            <div class="form-group">
-                                <input type="text" class="form-control" id="nickname" placeholder="닉네임">
+                            <legend>당신의 고민은 무엇인가요? <i class="bi bi-chat-dots"></i></legend>
+                            <div class="row">
+                                <div class="form-group">
+                                    <label for="title" class="form-label mt-4">제목</label>
+                                    <input type="text" class="form-control" id="title" placeholder="제목" maxlength="30">
+                                </div>
                             </div>
-                            <div class="form-group">
-                                <input type="text" class="form-control" id="title" placeholder="제목">
+                            <div class="row">
+                                <div class="col-md-6 form-group">
+                                    <label for="nickname" class="form-label">닉네임</label>
+                                    <input type="text" class="form-control" id="nickname" placeholder="닉네임" maxlength="7" disabled>
+                                    <small class="text-muted p-2">닉네임은 변경할 수 없습니다.</small>
+                                </div>
+
+                                <div class="col-md-6 form-group">
+                                    <label for="password" class="form-label">비밀번호</label>
+                                    <input type="password" class="form-control" id="password" placeholder="비밀번호 확인" maxlength="11">
+                                    <small class="text-muted p-2">비밀번호를 다시 입력해 주세요.</small>
+                                </div>
                             </div>
-                            <div class="form-group">
-                                <input type="password" class="form-control" id="password" placeholder="비밀번호 확인">
-                            </div>
-                            <div class="form-group">
-                                <textarea class="form-control" id="desc" rows="3" placeholder="고민거리를 나눠 보세요!"></textarea>
+                            <div class="row">
+                                <div class="form-group">
+                                    <label for="desc" class="form-label">내용</label>
+                                    <textarea class="form-control p-4" id="desc" rows="10" placeholder="고민거리를 나눠 보세요!"></textarea>
+                                </div>
                             </div>
 
-                            <button onclick="save_worry()" type="button" class="btn btn-secondary d-block ms-auto">작성하기</button>
+                            <div class="text-end mt-2" id="modal-btn-zone">
+                                <div class="btn-group">
+                                    <a href="/" class="btn btn-secondary">목록으로</a>
+                                </div>
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-primary modal-btn" id="edit-btn">수정하기</button>
+                                </div>
+                            </div>
                         </fieldset>
-                    </form>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/15-> develop

### 변경 사항
- 닉네임(7자), 비밀번호(11자), 제목(30자) 글자수 제한
- 수정 페이지에서 닉네임은 변경할 수 없도록 disabled
- 수정 페이지에 목록 버튼 추가
- view_count 데이터타입 String → int로 변경
- 수정 페이지에서 worry_detail 함수를 호출하므로 조회수 -2
- 수정 페이지에서 다시 비밀번호 확인
- 수정 후 상세조회 페이지로 이동

### 테스트 결과
수정 페이지로 들어갔다가 수정을 하지 않고 목록으로 나올 경우, 조회수가 +1 됩니다.
이 부분 어떻게 구현하는게 좋을까요?