### PR TITLE
feat: 게시글 삭제 기능 구현

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ def edit():
 # API 부분
 @app.route('/worry/list', methods=['GET'])
 def worry_list():
-    worry_list = list(db.worry.find({},{'_id':False}))
+    worry_list = list(db.worry.find({'deleted_at':None},{'_id':False}))
     return jsonify({'worries':worry_list})
 
 @app.route('/worry/detail', methods=['GET'])
@@ -61,7 +61,7 @@ def worry_create():
         'desc': desc_receive,
         'view_count': view_count,
         'created_at': now,
-        'deleted_at': 'null',
+        'deleted_at': None,
         'comment': [],
     }
     db.worry.insert_one(doc)
@@ -100,6 +100,18 @@ def worry_edit():
                                       'title':title_receive,
                                       'desc':desc_receive,
                                       'view_count':view_count}})
+        return jsonify({'msg': True})
+    else:
+        return jsonify({'msg': False})
+
+@app.route('/worry/delete', methods=["POST"])
+def worry_delete():
+    board_id_receive = int(request.form['board_id_give'])
+    now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    # updateResult 변수에 업데이트의 결과를 담아서 클라이언트로 전달(1: 성공, 0: 실패)
+    updateResult = db.worry.update_one({'board_id': board_id_receive},{'$set': {'deleted_at': now}})
+    if updateResult.modified_count == 1:
         return jsonify({'msg': True})
     else:
         return jsonify({'msg': False})

--- a/app.py
+++ b/app.py
@@ -35,13 +35,20 @@ def worry_list():
 @app.route('/worry/detail', methods=['GET'])
 def worry_detail():
     board_id = int(request.args.get('id'))
-    worry_detail = db.worry.find_one({'board_id': board_id},{'_id': False})
 
-    # 들어 오는 순간 바로 조회수1 증가 하고 update.
-    view_count = int(worry_detail['view_count']) + 1
-    db.worry.update_one({"board_id": board_id}, {"$set": {"view_count": view_count}})
-    worry_detail = db.worry.find_one({'board_id': board_id}, {'_id': False})
-    return jsonify({'worry': worry_detail})
+    # 쿼리 조건: 해당 board_id를 가지고 있고, deleted_at이 null인 데이터
+    # 해당 데이터가 없다면, 즉 삭제된 글이라면 None을 return
+    worry_detail = db.worry.find_one({'$and': [{'board_id': board_id}, {'deleted_at': None}]}, {'_id': False})
+
+    # 찾는 데이터가 있으면 True와 해당 데이터 return, 없으면 False return
+    if worry_detail != None:
+        # 들어 오는 순간 바로 조회수1 증가 하고 update.
+        view_count = int(worry_detail['view_count']) + 1
+        db.worry.update_one({"board_id": board_id}, {"$set": {"view_count": view_count}})
+        worry_detail = db.worry.find_one({'board_id': board_id}, {'_id': False})
+        return jsonify({'msg': True, 'worry': worry_detail})
+    else:
+        return jsonify({'msg': False})
 
 @app.route('/worry/create', methods=["POST"])
 def worry_create():

--- a/app.py
+++ b/app.py
@@ -89,11 +89,11 @@ def worry_edit():
     # 해당 board_id 데이터를 조회
     worry_detail = db.worry.find_one({'board_id': board_id_receive}, {'_id': False})
     password = worry_detail['password']
-    # /worry/detail을 2번 호출하기 때문에 -2
+    # /worry/detail을 2번 호출하기 때문에 view_count -2
     view_count = int(worry_detail['view_count']) - 2
 
     # 비밀번호가 일치하는지 확인 후
-    # 일치하면 update하고 True 리턴, 일치하지 않으면 False return
+    # 일치하면 update하고 True return, 일치하지 않으면 False return
     if password == password_receive:
         db.worry.update_one({'board_id': board_id_receive},
                             {'$set': {'nickname': nickname_receive,

--- a/static/assets/js/detail.js
+++ b/static/assets/js/detail.js
@@ -14,32 +14,34 @@ function detail() {
         data: {},
         success: function (response) {
 
-            // 게시글 부분
-            let rows = response['worry'];
-            let nickname = rows['nickname'];
-            let title = rows['title'];
-            let desc = rows['desc'];
-            let view_count = rows['view_count'];
-            let created_at = rows['created_at'];
+            // 해당 게시글이 삭제되지 않았으면, 화면에 출력
+            if (response['msg']) {
+                // 게시글 부분
+                let rows = response['worry'];
+                let nickname = rows['nickname'];
+                let title = rows['title'];
+                let desc = rows['desc'];
+                let view_count = rows['view_count'];
+                let created_at = rows['created_at'];
 
-            document.getElementById('nickname').innerText = nickname;
-            document.getElementById('title').innerText = title;
-            document.getElementById('desc').innerText = desc;
-            document.getElementById('view_count').innerText = view_count;
-            document.getElementById('created_at').innerText = created_at;
+                document.getElementById('nickname').innerText = nickname;
+                document.getElementById('title').innerText = title;
+                document.getElementById('desc').innerText = desc;
+                document.getElementById('view_count').innerText = view_count;
+                document.getElementById('created_at').innerText = created_at;
 
-            // 댓글 부분
-            document.getElementById('comment').innerHTML = '';
-            let comment = rows['comment'];
-            for (let i = 0; i < comment.length; i++) {
-                let comment_id = comment[i]['comment_id'];
-                let comment_nickname = comment[i]['nickname'];
-                let comment_password = comment[i]['password'];
-                let comment_desc = comment[i]['desc'];
-                let comment_created_at = comment[i]['created_at'];
-                let comment_likes =comment[i]['likes'];
+                // 댓글 부분
+                document.getElementById('comment').innerHTML = '';
+                let comment = rows['comment'];
+                for (let i = 0; i < comment.length; i++) {
+                    let comment_id = comment[i]['comment_id'];
+                    let comment_nickname = comment[i]['nickname'];
+                    let comment_password = comment[i]['password'];
+                    let comment_desc = comment[i]['desc'];
+                    let comment_created_at = comment[i]['created_at'];
+                    let comment_likes = comment[i]['likes'];
 
-                let temp_html = `<div class="comment mb-4 border-bottom">
+                    let temp_html = `<div class="comment mb-4 border-bottom">
                                     <div class="d-flex">
                                       <div class="comment-img"><img src="/static/assets/img/blog/comments-1.png" alt="comment-img" class="rounded-circle"></div>
                                       <div class="w-100">
@@ -53,7 +55,13 @@ function detail() {
                                       </div>
                                     </div>
                                 </div>`;
-                document.getElementById('comment').innerHTML += temp_html;
+                    document.getElementById('comment').innerHTML += temp_html;
+                }
+            }
+            // 해당 게시글이 삭제 되었으면, alert 띄우고 메인 페이지로 이동
+            else {
+                alert('삭제된 게시글입니다.')
+                window.location.replace('/');
             }
         }
     });
@@ -121,7 +129,7 @@ function del(board_id) {
         },
         success: function (response) {
 
-            // 삭제(deleted_at 업데이트)에 성공하면, alert 띄우고 메인페이지로 이동
+            // 삭제(deleted_at 업데이트)에 성공하면, alert 띄우고 메인 페이지로 이동
             if (response['msg']) {
                 alert('게시글이 삭제되었습니다.');
                 window.location.replace('/');

--- a/static/assets/js/detail.js
+++ b/static/assets/js/detail.js
@@ -94,9 +94,11 @@ function pw_check(edit_or_del) {
                 if (response['msg'] && edit_or_del === 'edit-btn') {
                     window.location.replace('/edit?id=' + board_id);
                 }
-                // 비밀번호가 일치하고, del 버튼을 클릭 했으면 alert
+                // 비밀번호가 일치하고, del 버튼을 클릭 했으면 alert 띄우고 del 함수 호출
                 else if (response['msg'] && edit_or_del === 'del-btn') {
-                    alert('정말 삭제하시겠습니까?');
+                    if (confirm('정말 삭제하시겠습니까?')) {
+                        del(board_id);
+                    }
                 }
                 // 비밀번호가 일치하지 않으면, 안내 문구 출력
                 else {
@@ -107,4 +109,27 @@ function pw_check(edit_or_del) {
             }
         });
     }
+}
+
+// 삭제여부 확인하고 게시글 삭제(deleted_at 업데이트)
+function del(board_id) {
+    $.ajax({
+        type: 'POST',
+        url: '/worry/delete',
+        data: {
+            board_id_give: board_id,
+        },
+        success: function (response) {
+
+            // 삭제(deleted_at 업데이트)에 성공하면, alert 띄우고 메인페이지로 이동
+            if (response['msg']) {
+                alert('게시글이 삭제되었습니다.');
+                window.location.replace('/');
+            }
+            // 삭제(deleted_at 업데이트)에 실패하면, 안내 alert
+            else {
+                alert('문제가 발생했습니다. 관리자에게 문의해 주세요.');
+            }
+        }
+    });
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/17-> develop

### 변경 사항
- 게시글 삭제는 DB delete가 아닌 deleted_at 키 값에 현재날짜 update로 구현
- deleted_at 데이터타입 Null로 변경(Python에서의 None이 Null로 간주된다고 합니다)
- worry_list(), worry_detail() 함수 내 쿼리문에 ‘deleted_at: None’ 조건 추가
- url을 통해 삭제된 게시글 번호로 직접 접근할 시, alert 후 메인 페이지로 이동하도록 구현
- 게시글 삭제 실패 시, 관리자 문의 요망 안내 문구 alert

### 테스트 결과
이상 없습니다.