### PR TITLE
refactor: 고민리스트 정렬

### DIFF
--- a/static/assets/js/list.js
+++ b/static/assets/js/list.js
@@ -1,51 +1,29 @@
 document.addEventListener('DOMContentLoaded', list);
 
-let sort_keyword = "worry-recent-list"
-
-function recent() {
-    sort_keyword = "worry-recent-list";
-    list();
-}
-function comment() {
-    sort_keyword = "worry-comment-list";
-    list();
-}
-function view() {
-    sort_keyword = "worry-view-list";
-    list();
-}
-
 function list() {
-    document.getElementById('worry-recent-list').innerHTML = '';
-    document.getElementById('worry-comment-list').innerHTML = '';
-    document.getElementById('worry-view-list').innerHTML = '';
     $.ajax({
         type: 'GET',
         url: '/worry/list',
         data: {},
         success: function (response) {
             let rows = response['worries'];
+            let recent_rows = [...rows].sort(function (a, b) {
+                        return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+                    });
+            let comment_rows = [...rows].sort(function (a, b) {
+                        return b.comment.length - a.comment.length;
+                    });
+            let view_rows = [...rows].sort(function (a, b) {
+                        return b.view_count - a.view_count;
+                    });
 
-            if (sort_keyword === "worry-recent-list") {
-                rows.sort(function (a, b) {
-                    return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-                });
-            } else if (sort_keyword === "worry-comment-list") {
-                rows.sort(function (a, b) {
-                    return b.comment.length - a.comment.length;
-                });
-            } else if (sort_keyword === "worry-view-list") {
-                rows.sort(function (a, b) {
-                    return b.view_count - a.view_count;
-                });
-            }
             for (let i = 0; i < rows.length; i++) {
-                let board_id = rows[i]['board_id'];
-                let nickname = rows[i]['nickname'];
-                let title = rows[i]['title'];
-                let view_count = rows[i]['view_count'];
-                let created_at = rows[i]['created_at'];
-                let comment_len = rows[i]['comment'].length;
+                let board_id = recent_rows[i]['board_id'];
+                let nickname = recent_rows[i]['nickname'];
+                let title = recent_rows[i]['title'];
+                let view_count = recent_rows[i]['view_count'];
+                let created_at = recent_rows[i]['created_at'];
+                let comment_len = recent_rows[i]['comment'].length;
                 let temp_html = `<tr class="table-light">
                                     <th scope="row">${board_id}</th>
                                     <td class="text-start"><a href="/detail?id=${board_id}">${title}<span style="font-size: small">(${comment_len})</span></a></td>
@@ -53,7 +31,39 @@ function list() {
                                     <td>${view_count}</td>
                                     <td>${created_at}</td>
                                 </tr>`;
-                document.getElementById(sort_keyword).innerHTML += temp_html;
+                document.getElementById('worry-recent-list').innerHTML += temp_html;
+            }
+            for (let i = 0; i < rows.length; i++) {
+                let board_id = comment_rows[i]['board_id'];
+                let nickname = comment_rows[i]['nickname'];
+                let title = comment_rows[i]['title'];
+                let view_count = comment_rows[i]['view_count'];
+                let created_at = comment_rows[i]['created_at'];
+                let comment_len = comment_rows[i]['comment'].length;
+                let temp_html = `<tr class="table-light">
+                                    <th scope="row">${board_id}</th>
+                                    <td class="text-start"><a href="/detail?id=${board_id}">${title}<span style="font-size: small">(${comment_len})</span></a></td>
+                                    <td class="text-start">${nickname}</td>
+                                    <td>${view_count}</td>
+                                    <td>${created_at}</td>
+                                </tr>`;
+                document.getElementById('worry-comment-list').innerHTML += temp_html;
+            }
+            for (let i = 0; i < rows.length; i++) {
+                let board_id = view_rows[i]['board_id'];
+                let nickname = view_rows[i]['nickname'];
+                let title = view_rows[i]['title'];
+                let view_count = view_rows[i]['view_count'];
+                let created_at = view_rows[i]['created_at'];
+                let comment_len = view_rows[i]['comment'].length;
+                let temp_html = `<tr class="table-light">
+                                    <th scope="row">${board_id}</th>
+                                    <td class="text-start"><a href="/detail?id=${board_id}">${title}<span style="font-size: small">(${comment_len})</span></a></td>
+                                    <td class="text-start">${nickname}</td>
+                                    <td>${view_count}</td>
+                                    <td>${created_at}</td>
+                                </tr>`;
+                document.getElementById('worry-view-list').innerHTML += temp_html;
             }
 
         }

--- a/templates/index.html
+++ b/templates/index.html
@@ -65,21 +65,21 @@
     <section id="features" class="features">
       <div class="container" data-aos="fade-up">
 
-        <ul class="nav nav-tabs row g-2 d-flex justify-content-center border-0 text-center">
+        <ul id="sort_wrap" class="nav nav-tabs row g-2 d-flex justify-content-center border-0 text-center">
 
           <li class="nav-item col-3">
-            <a onclick="recent()" href="" class="nav-link active show" data-bs-toggle="tab" data-bs-target="#tab-1">
+            <a id="recent-sort" href="" class="nav-link active show" data-bs-toggle="tab" data-bs-target="#tab-1">
               <h4>최신순</h4>
             </a>
           </li><!-- End tab nav item -->
 
           <li class="nav-item col-3">
-            <a onclick="comment()" href="" class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-2">
+            <a id="comment-sort" href="" class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-2">
               <h4>댓글순</h4>
             </a><!-- End tab nav item -->
 
           <li class="nav-item col-3">
-            <a onclick="view()" href="" class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-3">
+            <a id="view-sort"  href="" class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-3">
               <h4>조회순</h4>
             </a>
           </li><!-- End tab nav item -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,18 +68,18 @@
         <ul id="sort_wrap" class="nav nav-tabs row g-2 d-flex justify-content-center border-0 text-center">
 
           <li class="nav-item col-3">
-            <a id="recent-sort" href="" class="nav-link active show" data-bs-toggle="tab" data-bs-target="#tab-1">
+            <a href="" class="nav-link active show" data-bs-toggle="tab" data-bs-target="#tab-1">
               <h4>최신순</h4>
             </a>
           </li><!-- End tab nav item -->
 
           <li class="nav-item col-3">
-            <a id="comment-sort" href="" class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-2">
+            <a href="" class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-2">
               <h4>댓글순</h4>
             </a><!-- End tab nav item -->
 
           <li class="nav-item col-3">
-            <a id="view-sort"  href="" class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-3">
+            <a href="" class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-3">
               <h4>조회순</h4>
             </a>
           </li><!-- End tab nav item -->


### PR DESCRIPTION


### PR 타입
- [x] 코드 리팩토링
- [] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature14/ -> develop

### 변경 사항
- 정렬 a태그들의 onclick이벤트 삭제
- GET으로 받아온 고민리스트를 최신순,댓글순,조회순으로 정렬
- 최신순,댓글순,조회순 레이아웃에 각각 노출
- 따라서 클릭 시 reload되는 것 같은 깜박이는 현상 없어짐
- DB조회도 한 번만 하면 됨

### 테스트 결과
이상 없습니다.
